### PR TITLE
New feature split coverage file by suite or Behat feature

### DIFF
--- a/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
+++ b/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
@@ -33,6 +33,10 @@ final class RemoteCodeCoverageExtension implements Extension
                     ->isRequired()
                     ->info('The directory where the generated coverage files should be stored.')
                 ->end()
+                ->scalarNode('split_by')
+                    ->defaultValue('suite')
+                    ->info('The strategy to save/split coverage files by (suite or feature).')
+                ->end()
             ->end();
     }
 
@@ -42,5 +46,6 @@ final class RemoteCodeCoverageExtension implements Extension
         $loader->load('services.yml');
 
         $container->setParameter('remote_code_coverage.target_directory', $config['target_directory']);
+        $container->setParameter('remote_code_coverage.split_by', $config['split_by']);
     }
 }

--- a/src/BehatRemoteCodeCoverage/Resources/config/services.yml
+++ b/src/BehatRemoteCodeCoverage/Resources/config/services.yml
@@ -6,5 +6,6 @@ services:
             - '%mink.default_session%'
             - '%mink.base_url%'
             - '%remote_code_coverage.target_directory%'
+            - '%remote_code_coverage.split_by%'
         tags:
             - { name: event_dispatcher.subscriber }


### PR DESCRIPTION
Please consider merging this new feature to split coverage files by Behat feature. The default is still set to save by `suite` with a new configuration option of `split_by: 'feature'`. Thank you! 😸 