### PR TITLE
Split coverage by scenario

### DIFF
--- a/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
+++ b/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
@@ -33,9 +33,10 @@ final class RemoteCodeCoverageExtension implements Extension
                     ->isRequired()
                     ->info('The directory where the generated coverage files should be stored.')
                 ->end()
-                ->scalarNode('split_by')
+                ->enumNode('split_by')
                     ->defaultValue('suite')
-                    ->info('The strategy to save/split coverage files by (suite or feature).')
+                    ->values(['suite', 'feature', 'scenario'])
+                    ->info('The strategy to save/split coverage files by (suite, feature or scenario).')
                 ->end()
             ->end();
     }


### PR DESCRIPTION
Hello Matthias,

I suggest the availability to split coverage by scenario also.

It can help those who are using the `--list-scenario` behat extension which is listing all available scenarios with this extension:
https://github.com/liuggio/fastest

It can be quite useful on a CI when parallelization is needed on scenarios.

Thanks!