### PR TITLE
Fix @javascript scenarios

### DIFF
--- a/src/BehatRemoteCodeCoverage/Resources/config/services.yml
+++ b/src/BehatRemoteCodeCoverage/Resources/config/services.yml
@@ -3,7 +3,6 @@ services:
         class: BehatRemoteCodeCoverage\RemoteCodeCoverageListener
         arguments:
             - '@mink'
-            - '%mink.default_session%'
             - '%mink.base_url%'
             - '%remote_code_coverage.target_directory%'
             - '%remote_code_coverage.split_by%'


### PR DESCRIPTION
We have a behat configuration like this:

```yaml
default:
    suites:
        default:
            mink_session: default
            mink_javascript_session: javascript_chrome

# ...

    extensions:
        DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
        # See https://gitlab.com/DMore/chrome-mink-driver

        Behat\MinkExtension:
            # ...
            sessions:
                javascript_chrome:
                    chrome:
                        api_url: http://localhost:9222
```

The code coverage was not working with scenarios tagged with `@javascript`. The `RemoteCodeCoverageListener` was setting cookies only on the default mink session/driver. The fix for this is to just use `$this->mink->getSession()`.

Because of the way `setCookie` is implemented by the chrome mink driver: https://gitlab.com/DMore/chrome-mink-driver/-/blob/c86b0bbdef8609402dd4f24750a97f28a9797132/src/ChromeDriver.php#L381 `$this->page` was null when `setCookie` was called. So this is why I added `if (!$minkSession->isStarted()) { $minkSession->start();`.