### PR TITLE
Add base_url configuration option

### DIFF
--- a/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
+++ b/src/BehatRemoteCodeCoverage/RemoteCodeCoverageExtension.php
@@ -38,6 +38,10 @@ final class RemoteCodeCoverageExtension implements Extension
                     ->values(['suite', 'feature', 'scenario'])
                     ->info('The strategy to save/split coverage files by (suite, feature or scenario).')
                 ->end()
+                ->scalarNode('base_url')
+                    ->defaultNull()
+                    ->info('The base url of the php application, leave null to use mink base url.')
+                ->end()
             ->end();
     }
 
@@ -48,5 +52,6 @@ final class RemoteCodeCoverageExtension implements Extension
 
         $container->setParameter('remote_code_coverage.target_directory', $config['target_directory']);
         $container->setParameter('remote_code_coverage.split_by', $config['split_by']);
+        $container->setParameter('remote_code_coverage.base_url', $config['base_url'] ?: '%mink.base_url%');
     }
 }

--- a/src/BehatRemoteCodeCoverage/Resources/config/services.yml
+++ b/src/BehatRemoteCodeCoverage/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
         class: BehatRemoteCodeCoverage\RemoteCodeCoverageListener
         arguments:
             - '@mink'
-            - '%mink.base_url%'
+            - '%remote_code_coverage.base_url%'
             - '%remote_code_coverage.target_directory%'
             - '%remote_code_coverage.split_by%'
         tags:


### PR DESCRIPTION
The use case is an application with two hostnames, one for the frontend (nginx/static), and one for the backend/api (php/symfony).

Mink is configured with the frontend url, but I need the listener to call the backend hostname.